### PR TITLE
feat: add MAC address request functionality

### DIFF
--- a/backend/swarms/README.md
+++ b/backend/swarms/README.md
@@ -19,10 +19,13 @@ RESTful API for managing IoT device swarms with authentication, role-based acces
 ### Core Functionality
 - ✅ **Swarm Management** - Create, update, delete, and monitor IoT device swarms
 - ✅ **Device Management** - Direct device registration and assignment to swarms
+- ✅ **MAC Address Requests** - Request specific existing devices by MAC address during swarm creation
+- ✅ **Auto-Assignment** - Automatic assignment of available devices based on requested MACs
+- ✅ **Device Availability Check** - Verify device existence and availability before assignment
 - ✅ **State Management** - Request → Assign → Activate → Pause/Complete workflow
 - ✅ **Real-time Monitoring** - Device online/offline status and battery tracking
 - ✅ **Statistics** - Real-time swarm and device analytics
-- ✅ **Role-based Access Control** - Owner, Leader, User permissions
+- ✅ **Role-based Access Control** - Organization, Cluster manager, Project manager permissions
 
 ### Security & Infrastructure
 - 🔐 **JWT Authentication** - Bearer token validation
@@ -74,6 +77,7 @@ CREATE TABLE device_swarms (
     project_id integer,
     cluster_manager_id integer,
     status varchar(20) DEFAULT 'requested',
+    requested_macs jsonb,  -- NEW: Array of requested MAC addresses
     created_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP,
     assigned_at timestamp without time zone,
     activated_at timestamp without time zone,
@@ -93,13 +97,18 @@ CREATE TABLE esp32_devices (
     device_name varchar(100),
     mac_address varchar(17),
     firmware_version varchar(50),
-    last_ip_address inet,
+    last_ip_address varchar(50),  -- Updated to varchar(50)
     device_type varchar(50) DEFAULT 'ESP32',
     location varchar(200),
     installation_date timestamp with time zone DEFAULT CURRENT_TIMESTAMP,
     last_seen timestamp with time zone DEFAULT CURRENT_TIMESTAMP,
     is_online boolean DEFAULT false,
     battery_level numeric(5,2),
+    role varchar(50) DEFAULT 'sensor',  -- NEW: Device role
+    assigned_at timestamp without time zone DEFAULT now(),  -- NEW
+    assigned_by integer,  -- NEW: User who assigned the device
+    removed_at timestamp without time zone,  -- NEW
+    status varchar(20) DEFAULT 'assigned',  -- NEW: Device status
     created_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP,
     updated_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP
 );
@@ -108,7 +117,7 @@ CREATE TABLE esp32_devices (
 ### Status Flow
 ```
 Swarm Status: requested → assigned → active → paused/completed/rejected
-Device Status: Directly managed (online/offline, assigned to swarm or not)
+Device Status: assigned → unassigned → maintenance → inactive
 ```
 
 ## Environment Variables
@@ -164,6 +173,9 @@ npm ci
 # Enable UUID extension in PostgreSQL
 CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
 
+# Add the new column to existing database
+ALTER TABLE device_swarms ADD COLUMN requested_macs JSONB;
+
 # Configure environment
 touch .env
 # Edit .env with your configuration (see Environment Variables section)
@@ -188,8 +200,9 @@ Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
 
 | Role | Permissions |
 |------|-------------|
-| **Owner** | Full access to all swarms and operations |
-| **Leader** | Can manage swarms, assign, activate, reject swarms |
+| **Organization** | Full access to all swarms and operations |
+| **Cluster manager** | Can manage assigned swarms, activate, pause, complete |
+| **Project manager** | Can create swarms and manage own swarms |
 
 ### Getting a Token
 Use the token obtained when logging into the system. This token will be automatically included in requests when using the frontend application.
@@ -206,21 +219,24 @@ Use the token obtained when logging into the system. This token will be automati
 | Method | Endpoint | Description | Roles |
 |--------|----------|-------------|-------|
 | **CRUD Operations** |
-| POST | `/swarms` | Create new swarm | All |
+| POST | `/swarms` | Create new swarm with optional MAC requests | All |
 | GET | `/swarms` | Get all swarms | All |
 | GET | `/swarms/:id` | Get specific swarm | All |
-| PUT | `/swarms/:id` | Update swarm | Owner, Creator |
-| DELETE | `/swarms/:id` | Delete swarm | Owner, Creator |
+| PUT | `/swarms/:id` | Update swarm | Organization, Cluster manager, Creator |
+| DELETE | `/swarms/:id` | Delete swarm | Organization, Cluster manager, Creator |
 | **State Management** |
-| POST | `/swarms/:id/assign` | Assign to cluster manager | Owner, Leader |
-| POST | `/swarms/:id/activate` | Activate swarm | Owner, Leader |
+| POST | `/swarms/:id/assign` | Assign to cluster manager | Organization, Cluster manager |
+| POST | `/swarms/:id/activate` | Activate swarm | Organization, Cluster manager |
 | POST | `/swarms/:id/pause` | Pause swarm | All |
 | POST | `/swarms/:id/complete` | Complete swarm | All |
-| POST | `/swarms/:id/reject` | Reject swarm | Owner, Leader |
+| POST | `/swarms/:id/reject` | Reject swarm | Organization, Cluster manager |
 | **Device Management** |
 | GET | `/swarms/:id/devices` | Get swarm devices | All |
 | POST | `/swarms/:id/devices` | Assign existing device to swarm | All |
 | DELETE | `/swarms/:id/devices/:deviceId` | Remove device from swarm | All |
+| POST | `/swarms/:id/assign-requested-devices` | Assign devices based on requested MACs | Organization, Cluster manager |
+| **MAC Address Management** |
+| GET | `/swarms/:id/requested-macs-status` | Get status of requested MACs | All |
 | **Analytics** |
 | GET | `/swarms/:id/stats` | Get swarm statistics | All |
 
@@ -228,7 +244,7 @@ Use the token obtained when logging into the system. This token will be automati
 
 ### 1. Basic CRUD Operations
 
-#### Create New Swarm
+#### Create New Swarm (Simple - without MAC requests)
 ```bash
 curl -X POST http://localhost:3000/swarms \
   -H "Content-Type: application/json" \
@@ -242,6 +258,68 @@ curl -X POST http://localhost:3000/swarms \
   }'
 ```
 
+### Device Availability and MAC Requests
+
+#### Important: MAC Address Requirements
+The `requestedMacs` field should contain MAC addresses of devices that:
+- **Already exist** in the `esp32_devices` table
+- **Are available** (have `swarm_id = NULL`)
+- **Are not assigned** to any other swarm
+
+When you request MACs during swarm creation, the system will validate that these devices exist and are available for assignment.
+
+#### Create New Swarm with Requested MACs (Simple format)
+```bash
+curl -X POST http://localhost:3000/swarms \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer your-jwt-token" \
+  -d '{
+    "name": "Temperature Monitoring Swarm",
+    "description": "Monitoring temperature in building A",
+    "maxDevices": 10,
+    "projectId": 123,
+    "location": "Building A",
+    "requestedMacs": [
+      "AA:BB:CC:DD:EE:FF",
+      "11:22:33:44:55:66",
+      "77:88:99:AA:BB:CC"
+    ]
+  }'
+```
+
+**Note:** These MAC addresses must correspond to existing devices in your database that are currently unassigned.
+
+#### Create New Swarm with Requested MACs (Extended format with metadata)
+```bash
+curl -X POST http://localhost:3000/swarms \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer your-jwt-token" \
+  -d '{
+    "name": "Smart Building Sensors",
+    "description": "Complete building monitoring system",
+    "maxDevices": 15,
+    "projectId": 456,
+    "location": "Smart Building Tower",
+    "requestedMacs": [
+      {
+        "mac": "AA:BB:CC:DD:EE:FF",
+        "deviceName": "Temperature Sensor Office 1",
+        "notes": "Northeast corner, near window"
+      },
+      {
+        "mac": "11:22:33:44:55:66",
+        "deviceName": "Humidity Sensor Hallway",
+        "notes": "Central hallway, ceiling mounted"
+      },
+      {
+        "mac": "77:88:99:AA:BB:CC",
+        "deviceName": "Motion Detector Main Entrance",
+        "notes": "Above main door, battery powered"
+      }
+    ]
+  }'
+```
+
 **Response:**
 ```json
 {
@@ -250,16 +328,37 @@ curl -X POST http://localhost:3000/swarms \
   "data": {
     "swarm": {
       "swarmId": "550e8400-e29b-41d4-a716-446655440000",
-      "swarmName": "Urban Sensor Network",
-      "description": "Environmental monitoring downtown",
-      "maxDevices": 50,
+      "swarmName": "Smart Building Sensors",
+      "description": "Complete building monitoring system",
+      "maxDevices": 15,
       "requesterId": 456,
-      "projectId": 123,
-      "location": "Downtown Area",
+      "projectId": 456,
+      "location": "Smart Building Tower",
       "status": "requested",
+      "requestedMacs": [
+        {
+          "mac": "AA:BB:CC:DD:EE:FF",
+          "deviceName": "Temperature Sensor Office 1",
+          "notes": "Northeast corner, near window",
+          "requestedAt": "2025-08-18T15:30:00.000Z"
+        },
+        {
+          "mac": "11:22:33:44:55:66",
+          "deviceName": "Humidity Sensor Hallway",
+          "notes": "Central hallway, ceiling mounted",
+          "requestedAt": "2025-08-18T15:30:00.000Z"
+        },
+        {
+          "mac": "77:88:99:AA:BB:CC",
+          "deviceName": "Motion Detector Main Entrance",
+          "notes": "Above main door, battery powered",
+          "requestedAt": "2025-08-18T15:30:00.000Z"
+        }
+      ],
       "isActive": true,
-      "createdAt": "2025-08-07T15:30:00.000Z"
-    }
+      "createdAt": "2025-08-18T15:30:00.000Z"
+    },
+    "requestedMacsCount": 3
   }
 }
 ```
@@ -268,6 +367,10 @@ curl -X POST http://localhost:3000/swarms \
 ```bash
 # Get all swarms
 curl -X GET http://localhost:3000/swarms \
+  -H "Authorization: Bearer your-jwt-token"
+
+# Get swarms with requested MACs included
+curl -X GET "http://localhost:3000/swarms?includeMacs=true" \
   -H "Authorization: Bearer your-jwt-token"
 
 # Filter by status
@@ -289,110 +392,91 @@ curl -X GET "http://localhost:3000/swarms?status=active&projectId=123" \
 - `clusterManagerId` - Filter by assigned cluster manager ID
 - `projectId` - Filter by project ID
 - `location` - Filter by location (partial match)
+- `includeMacs` - Include requested MACs in response (`true`/`false`)
 
-**Response:**
-```json
-{
-  "success": true,
-  "data": {
-    "swarms": [
-      {
-        "swarmId": "550e8400-e29b-41d4-a716-446655440000",
-        "swarmName": "Urban Sensor Network",
-        "status": "active",
-        "location": "Downtown Area",
-        "devices": [
-          {
-            "deviceId": "660e8400-e29b-41d4-a716-446655440001",
-            "deviceName": "Temperature Sensor 01",
-            "deviceType": "ESP32",
-            "isOnline": true,
-            "batteryLevel": 85.5
-          }
-        ]
-      }
-    ],
-    "count": 1,
-    "userContext": {
-      "userId": 456,
-      "rol": "Leader"
-    }
-  }
-}
-```
-
-#### Update Swarm
+#### Update Swarm with MAC Requests
 ```bash
 curl -X PUT http://localhost:3000/swarms/550e8400-e29b-41d4-a716-446655440000 \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer your-jwt-token" \
   -d '{
-    "name": "Urban Sensor Network - Updated",
-    "description": "Updated environmental monitoring",
-    "maxDevices": 75,
-    "location": "Extended Downtown Area"
+    "name": "Smart Building Sensors - Updated",
+    "description": "Updated complete building monitoring system",
+    "maxDevices": 20,
+    "location": "Smart Building Tower - Floors 1-3",
+    "requestedMacs": [
+      "AA:BB:CC:DD:EE:FF",
+      "11:22:33:44:55:66",
+      "77:88:99:AA:BB:CC",
+      "88:99:AA:BB:CC:DD"
+    ]
   }'
 ```
 
-### 2. State Management Workflow
+### 2. State Management Workflow with Auto-Assignment
 
-#### Assign Swarm to Cluster Manager
+#### Assign Swarm to Cluster Manager (with auto-assignment)
 ```bash
 curl -X POST http://localhost:3000/swarms/550e8400-e29b-41d4-a716-446655440000/assign \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer your-jwt-token" \
   -d '{
-    "clusterManagerId": 789
+    "clusterManagerId": 789,
+    "autoAssignDevices": true
   }'
 ```
 
-#### Activate Swarm
-```bash
-curl -X POST http://localhost:3000/swarms/550e8400-e29b-41d4-a716-446655440000/activate \
-  -H "Authorization: Bearer your-jwt-token"
-```
-
-#### Pause Swarm
-```bash
-curl -X POST http://localhost:3000/swarms/550e8400-e29b-41d4-a716-446655440000/pause \
-  -H "Authorization: Bearer your-jwt-token"
-```
-
-### 3. Device Management
-
-#### Assign Existing Device to Swarm
-```bash
-curl -X POST http://localhost:3000/swarms/550e8400-e29b-41d4-a716-446655440000/devices \
-  -H "Content-Type: application/json" \
-  -H "Authorization: Bearer your-jwt-token" \
-  -d '{
-    "deviceId": "660e8400-e29b-41d4-a716-446655440001"
-  }'
-```
-
-**Response:**
+**Response with auto-assignment results:**
 ```json
 {
   "success": true,
-  "message": "Device added to swarm successfully",
+  "message": "Swarm assigned successfully",
   "data": {
-    "device": {
-      "deviceId": "660e8400-e29b-41d4-a716-446655440001",
+    "swarm": {
       "swarmId": "550e8400-e29b-41d4-a716-446655440000",
-      "deviceName": "Temperature Sensor 01",
-      "deviceType": "ESP32",
-      "macAddress": "AA:BB:CC:DD:EE:FF",
-      "isOnline": true,
-      "batteryLevel": 85.5,
-      "location": "Corner of Main St"
+      "status": "assigned",
+      "clusterManagerId": 789,
+      "assignedAt": "2025-08-18T16:00:00.000Z"
+    },
+    "autoAssignmentResults": {
+      "assigned": [
+        {
+          "mac": "AA:BB:CC:DD:EE:FF",
+          "deviceId": "660e8400-e29b-41d4-a716-446655440001",
+          "deviceName": "Temperature Sensor Office 1",
+          "reason": "Successfully assigned"
+        },
+        {
+          "mac": "11:22:33:44:55:66",
+          "deviceId": "660e8400-e29b-41d4-a716-446655440002",
+          "deviceName": "Humidity Sensor Hallway",
+          "reason": "Successfully assigned"
+        }
+      ],
+      "notFound": [
+        {
+          "mac": "77:88:99:AA:BB:CC",
+          "reason": "Device not found in database"
+        }
+      ],
+      "alreadyAssigned": [],
+      "unavailable": []
     }
   }
 }
 ```
 
-#### Get Swarm Devices
+#### Auto-Assignment Results Explanation:
+- **`assigned`** - Devices that were successfully assigned to the swarm
+- **`notFound`** - MAC addresses that don't exist in the database
+- **`alreadyAssigned`** - Devices that are already assigned to other swarms
+- **`unavailable`** - Devices that exist but are not available for assignment
+
+### 3. MAC Address Management
+
+#### Get Status of Requested MACs
 ```bash
-curl -X GET http://localhost:3000/swarms/550e8400-e29b-41d4-a716-446655440000/devices \
+curl -X GET http://localhost:3000/swarms/550e8400-e29b-41d4-a716-446655440000/requested-macs-status \
   -H "Authorization: Bearer your-jwt-token"
 ```
 
@@ -403,41 +487,108 @@ curl -X GET http://localhost:3000/swarms/550e8400-e29b-41d4-a716-446655440000/de
   "data": {
     "swarm": {
       "swarmId": "550e8400-e29b-41d4-a716-446655440000",
-      "swarmName": "Urban Sensor Network",
-      "status": "active"
+      "swarmName": "Smart Building Sensors",
+      "status": "assigned"
     },
-    "devices": [
+    "requestedMacs": [
       {
+        "mac": "AA:BB:CC:DD:EE:FF",
+        "deviceName": "Temperature Sensor Office 1",
+        "notes": "Northeast corner, near window",
+        "requestedAt": "2025-08-18T15:30:00.000Z",
+        "status": "assigned_to_this_swarm",
         "deviceId": "660e8400-e29b-41d4-a716-446655440001",
-        "deviceName": "Temperature Sensor 01",
-        "deviceType": "ESP32",
-        "macAddress": "AA:BB:CC:DD:EE:FF",
-        "firmwareVersion": "v1.2.3",
-        "lastIpAddress": "192.168.1.100",
-        "location": "Corner of Main St",
+        "currentSwarmId": "550e8400-e29b-41d4-a716-446655440000",
+        "deviceStatus": "assigned",
         "isOnline": true,
-        "batteryLevel": 85.5,
-        "lastSeen": "2025-08-07T15:25:00.000Z",
-        "swarm": {
-          "swarmId": "550e8400-e29b-41d4-a716-446655440000",
-          "swarmName": "Urban Sensor Network"
-        }
+        "batteryLevel": 85.5
+      },
+      {
+        "mac": "11:22:33:44:55:66",
+        "deviceName": "Humidity Sensor Hallway",
+        "notes": "Central hallway, ceiling mounted",
+        "requestedAt": "2025-08-18T15:30:00.000Z",
+        "status": "available",
+        "deviceId": "660e8400-e29b-41d4-a716-446655440003",
+        "deviceName": "Humidity Sensor Device",
+        "currentSwarmId": null,
+        "deviceStatus": "unassigned",
+        "isOnline": false,
+        "batteryLevel": 67.2
+      },
+      {
+        "mac": "77:88:99:AA:BB:CC",
+        "deviceName": "Motion Detector Main Entrance",
+        "notes": "Above main door, battery powered",
+        "requestedAt": "2025-08-18T15:30:00.000Z",
+        "status": "not_found",
+        "deviceId": null,
+        "deviceName": null,
+        "currentSwarmId": null,
+        "reason": "Device not found in database"
+      },
+      {
+        "mac": "88:99:AA:BB:CC:DD",
+        "deviceName": "Air Quality Sensor",
+        "notes": "Conference room sensor",
+        "requestedAt": "2025-08-18T15:30:00.000Z",
+        "status": "assigned_elsewhere",
+        "deviceId": "660e8400-e29b-41d4-a716-446655440004",
+        "deviceName": "Air Quality Monitor",
+        "currentSwarmId": "another-swarm-id",
+        "reason": "Already assigned to another swarm"
       }
     ],
-    "count": 1
+    "macsStatus": {
+      "total": 4,
+      "assigned": 1,
+      "available": 1,
+      "notFound": 1,
+      "assignedElsewhere": 1
+    }
   }
 }
 ```
 
-#### Remove Device from Swarm
+#### MAC Status Types:
+- **`assigned_to_this_swarm`** - Device successfully assigned to this swarm
+- **`available`** - Device exists and is available for assignment (swarm_id = NULL)
+- **`not_found`** - MAC address doesn't exist in the database
+- **`assigned_elsewhere`** - Device is already assigned to another swarm
+
+#### Manual Device Assignment Based on Requested MACs
 ```bash
-curl -X DELETE http://localhost:3000/swarms/550e8400-e29b-41d4-a716-446655440000/devices/660e8400-e29b-41d4-a716-446655440001 \
+curl -X POST http://localhost:3000/swarms/550e8400-e29b-41d4-a716-446655440000/assign-requested-devices \
   -H "Authorization: Bearer your-jwt-token"
 ```
 
-### 4. Analytics & Statistics
+### 4. Device Management
 
-#### Get Swarm Statistics
+#### Assign Device by MAC Address
+```bash
+curl -X POST http://localhost:3000/swarms/550e8400-e29b-41d4-a716-446655440000/devices \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer your-jwt-token" \
+  -d '{
+    "macAddress": "11:22:33:44:55:66",
+    "deviceRole": "sensor"
+  }'
+```
+
+#### Assign Device by Device ID
+```bash
+curl -X POST http://localhost:3000/swarms/550e8400-e29b-41d4-a716-446655440000/devices \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer your-jwt-token" \
+  -d '{
+    "deviceId": "660e8400-e29b-41d4-a716-446655440001",
+    "deviceRole": "coordinator"
+  }'
+```
+
+### 5. Enhanced Analytics & Statistics
+
+#### Get Swarm Statistics with MAC Information
 ```bash
 curl -X GET http://localhost:3000/swarms/550e8400-e29b-41d4-a716-446655440000/stats \
   -H "Authorization: Bearer your-jwt-token"
@@ -450,21 +601,35 @@ curl -X GET http://localhost:3000/swarms/550e8400-e29b-41d4-a716-446655440000/st
   "data": {
     "swarm": {
       "swarmId": "550e8400-e29b-41d4-a716-446655440000",
-      "swarmName": "Urban Sensor Network",
+      "swarmName": "Smart Building Sensors",
       "status": "active",
-      "maxDevices": 50
+      "maxDevices": 15
     },
     "stats": {
-      "totalDevices": 15,
-      "onlineDevices": 12,
-      "offlineDevices": 3,
+      "totalDevices": 8,
+      "onlineDevices": 6,
+      "offlineDevices": 2,
       "devicesByType": {
-        "ESP32": 12,
-        "Arduino": 3
+        "ESP32": 6,
+        "Arduino": 2
+      },
+      "devicesByRole": {
+        "sensor": 7,
+        "coordinator": 1
+      },
+      "devicesByStatus": {
+        "assigned": 8
       },
       "averageBatteryLevel": 73,
-      "lowBatteryDevices": 2,
-      "utilizationPercentage": 30
+      "lowBatteryDevices": 1,
+      "utilizationPercentage": 53,
+      "recentlyAssigned": 2
+    },
+    "macsStats": {
+      "totalRequested": 3,
+      "assignedFromRequested": 2,
+      "pendingAssignment": 0,
+      "notFound": 1
     }
   }
 }
@@ -489,45 +654,44 @@ curl -X GET http://localhost:3000/swarms/550e8400-e29b-41d4-a716-446655440000/st
   "success": false,
   "message": "Error description",
   "errors": ["Detailed error messages"],
-  "timestamp": "2025-08-07T15:30:00.000Z"
+  "timestamp": "2025-08-18T15:30:00.000Z"
 }
 ```
 
 ### Common Error Examples
 
-#### Authentication Error
+#### MAC Address Validation Error
 ```json
 {
   "success": false,
-  "message": "Invalid or expired token",
-  "timestamp": "2025-08-07T15:30:00.000Z"
+  "message": "Invalid MAC address format: XX:YY:ZZ:AA:BB:CC",
+  "timestamp": "2025-08-18T15:30:00.000Z"
 }
 ```
 
-#### Validation Error
-```json
-{
-  "success": false,
-  "message": "Name, maxDevices and projectId are required",
-  "timestamp": "2025-08-07T15:30:00.000Z"
-}
+#### Device Prerequisites for MAC Requests
+Before requesting devices by MAC address, ensure:
+
+1. **Devices exist** in the `esp32_devices` table
+2. **Devices are available** (`swarm_id` is `NULL`)
+3. **MAC addresses are valid** (format: `XX:XX:XX:XX:XX:XX`)
+4. **Devices are not assigned** to other swarms
+
+#### Example: Check Available Devices
+```sql
+-- Find available devices (ready for assignment)
+SELECT device_id, device_name, mac_address, device_type, is_online, battery_level
+FROM esp32_devices 
+WHERE swarm_id IS NULL 
+AND mac_address IS NOT NULL;
 ```
 
-#### Device Already Assigned Error
+#### Duplicate MAC Addresses Error
 ```json
 {
   "success": false,
-  "message": "Device is already assigned to another swarm",
-  "timestamp": "2025-08-07T15:30:00.000Z"
-}
-```
-
-#### Swarm Capacity Error
-```json
-{
-  "success": false,
-  "message": "Swarm has reached its limit of 50 devices",
-  "timestamp": "2025-08-07T15:30:00.000Z"
+  "message": "Duplicate MAC addresses in request",
+  "timestamp": "2025-08-18T15:30:00.000Z"
 }
 ```
 
@@ -570,12 +734,45 @@ backend/
     └── ...
 ```
 
-### Key Changes from Previous Version
-- **UUID Primary Keys**: All entities now use UUID instead of integer IDs
-- **Direct Device-Swarm Relationship**: Simplified many-to-many relationship removed
-- **Enhanced Device Properties**: Added MAC address, IP address, battery level, online status
-- **Location Support**: Both swarms and devices can have location information
-- **Real-time Monitoring**: Device online/offline status and last seen timestamps
+### Key Features in This Version
+- **UUID Primary Keys**: All entities use UUID instead of integer IDs
+- **Requested MACs Support**: Project managers can request specific devices by MAC address
+- **Auto-Assignment**: Automatic device assignment when swarms are assigned to cluster managers
+- **Enhanced Device Properties**: MAC address, IP address, battery level, online status, role, assignment tracking
+- **Real-time MAC Status**: Track the status of requested MAC addresses
+- **Comprehensive Statistics**: Enhanced analytics including MAC assignment statistics
+
+### Workflow Summary
+1. **Project Manager** creates swarm with requested MACs of **existing available devices** → Status: `requested`
+2. **Organization/Cluster Manager** assigns swarm → Status: `assigned` + **automatic assignment of available devices**
+3. **System** searches for each MAC in `esp32_devices` table and assigns devices where `swarm_id = NULL`
+4. **Cluster Manager** activates swarm → Status: `active`
+5. **Anyone** can pause/complete swarm → Status: `paused`/`completed`
+
+### MAC Address Workflow
+```
+┌─────────────────────┐    ┌─────────────────────┐    ┌─────────────────────┐
+│   Project Manager   │    │   Existing Devices  │    │   Auto-Assignment   │
+│   Requests MACs     │    │   in Database       │    │   Process           │
+└──────────┬──────────┘    └──────────┬──────────┘    └──────────┬──────────┘
+           │                          │                          │
+           │ 1. Create swarm with     │                          │
+           │    MAC addresses         │                          │
+           │ ────────────────────────▶│                         │
+           │                          │                          │
+           │                          │ 2. Validate MACs exist  │
+           │                          │    and are available    │
+           │                          │ ────────────────────────▶│
+           │                          │                          │
+           │                          │                          │ 3. When assigned:
+           │                          │                          │    Find devices by MAC
+           │                          │                          │    Where swarm_id = NULL
+           │                          │                          │    Assign to swarm
+           │                          │ ◀────────────────────────│
+           │                          │                          │
+           │ 4. Assignment results    │                          │
+           │ ◀────────────────────────────────────────────────────│
+```
 
 ### Scripts
 ```bash

--- a/backend/swarms/src/controllers/swarmController.js
+++ b/backend/swarms/src/controllers/swarmController.js
@@ -4,13 +4,20 @@ import logger from '../utils/logger.js'
 
 const { Swarm, Device } = models
 
-// @desc    Create new swarm
+// @desc    Create new swarm (ACTUALIZADO para manejar MACs solicitadas)
 // @route   POST /swarms
 // @access  Private (requires Bearer token)
 export const createSwarm = async (req, res, next) => {
   try {
     const { userId, email, role } = req.user
-    const { name, description, maxDevices, projectId, location } = req.body
+    const { 
+      name, 
+      description, 
+      maxDevices, 
+      projectId, 
+      location,
+      requestedMacs  // NUEVO: Array de MACs solicitadas
+    } = req.body
 
     logger.info(`User ${email} (${role}) creating swarm: ${name}`)
 
@@ -27,7 +34,44 @@ export const createSwarm = async (req, res, next) => {
       return errorResponse(res, 'maxDevices must be between 1 and 1000', 400)
     }
 
-    const swarm = await Swarm.create({
+    // NUEVO: Validar MACs si se proporcionan
+    if (requestedMacs) {
+      if (!Array.isArray(requestedMacs)) {
+        return errorResponse(res, 'requestedMacs must be an array', 400)
+      }
+
+      if (requestedMacs.length > maxDevices) {
+        return errorResponse(
+          res, 
+          `Cannot request more MACs (${requestedMacs.length}) than maxDevices (${maxDevices})`, 
+          400
+        )
+      }
+
+      // Validar formato de MACs
+      const macRegex = /^([0-9A-F]{2}[:-]){5}([0-9A-F]{2})$/i
+      for (const macEntry of requestedMacs) {
+        const macAddress = typeof macEntry === 'string' ? macEntry : macEntry.mac
+        if (!macAddress || !macRegex.test(macAddress)) {
+          return errorResponse(
+            res, 
+            `Invalid MAC address format: ${macAddress}`, 
+            400
+          )
+        }
+      }
+
+      // Verificar MACs duplicadas en la solicitud
+      const macs = requestedMacs.map(entry => 
+        typeof entry === 'string' ? entry : entry.mac
+      )
+      const uniqueMacs = new Set(macs)
+      if (uniqueMacs.size !== macs.length) {
+        return errorResponse(res, 'Duplicate MAC addresses in request', 400)
+      }
+    }
+
+    const swarmData = {
       swarmName: name,
       description,
       maxDevices,
@@ -35,13 +79,37 @@ export const createSwarm = async (req, res, next) => {
       projectId,
       location,
       status: 'requested',
-    })
+    }
 
-    logger.info(`New swarm created: ${swarm.swarmId} by user: ${userId}`)
+    // NUEVO: Agregar MACs solicitadas si se proporcionan
+    if (requestedMacs && requestedMacs.length > 0) {
+      // Formatear las MACs con metadata adicional
+      swarmData.requestedMacs = requestedMacs.map(entry => {
+        if (typeof entry === 'string') {
+          return entry
+        } else {
+          return {
+            mac: entry.mac,
+            deviceName: entry.deviceName || null,
+            notes: entry.notes || null,
+            requestedAt: new Date()
+          }
+        }
+      })
+    }
+
+    const swarm = await Swarm.create(swarmData)
+
+    logger.info(`New swarm created: ${swarm.swarmId} by user: ${userId}${
+      requestedMacs ? ` with ${requestedMacs.length} requested MACs` : ''
+    }`)
 
     return successResponse(
       res,
-      { swarm },
+      { 
+        swarm,
+        requestedMacsCount: requestedMacs ? requestedMacs.length : 0
+      },
       'Swarm created successfully',
       201
     )
@@ -51,13 +119,13 @@ export const createSwarm = async (req, res, next) => {
   }
 }
 
-// @desc    Get all swarms
+// @desc    Get all swarms (ACTUALIZADO para incluir requested MACs en respuesta)
 // @route   GET /swarms
 // @access  Private (requires Bearer token)
 export const getSwarms = async (req, res, next) => {
   try {
     const { userId, role } = req.user
-    const { status, requesterId, clusterManagerId, projectId, location } = req.query
+    const { status, requesterId, clusterManagerId, projectId, location, includeMacs } = req.query
 
     // Build filters
     const where = {}
@@ -67,25 +135,62 @@ export const getSwarms = async (req, res, next) => {
     if (projectId) where.projectId = projectId
     if (location) where.location = { [models.Sequelize.Op.iLike]: `%${location}%` }
 
-    // Apply role-based filters - CORREGIDO
+    // Apply role-based filters
     if (role !== 'Organization' && role !== 'Cluster manager') {
       where.requesterId = userId
     }
 
+    // NUEVO: Determinar atributos basado en si se solicitan las MACs
+    const attributes = [
+      'swarmId', 'swarmName', 'description', 'maxDevices', 
+      'requesterId', 'projectId', 'clusterManagerId', 'status',
+      'assignedAt', 'activatedAt', 'completedAt', 'lastActivity',
+      'location', 'isActive'
+    ]
+
+    // Solo incluir requestedMacs si se solicita explícitamente o si el usuario es admin
+    if (includeMacs === 'true' || role === 'Organization' || role === 'Cluster manager') {
+      attributes.push('requestedMacs')
+    }
+
     const swarms = await Swarm.findAll({
       where,
+      attributes,
       include: [
         {
           model: Device,
           as: 'devices',
-          attributes: ['deviceId', 'deviceName', 'deviceType', 'isOnline', 'batteryLevel'],
+          attributes: [
+            'deviceId', 
+            'deviceName', 
+            'deviceType', 
+            'isOnline', 
+            'batteryLevel',
+            'role',
+            'status',
+            'assignedAt',
+            'macAddress',
+            'firmwareVersion'
+          ],
         },
       ],
       order: [['created_at', 'DESC']],
     })
 
+    // NUEVO: Agregar estadísticas de MACs solicitadas
+    const swarmsWithMacStats = swarms.map(swarm => {
+      const swarmData = swarm.toJSON()
+      
+      if (swarmData.requestedMacs) {
+        swarmData.requestedMacsCount = swarmData.requestedMacs.length
+        swarmData.requestedMacsFormatted = swarm.getRequestedMacsFormatted()
+      }
+      
+      return swarmData
+    })
+
     return successResponse(res, {
-      swarms,
+      swarms: swarmsWithMacStats,
       count: swarms.length,
       userContext: { userId, role }
     })
@@ -95,7 +200,7 @@ export const getSwarms = async (req, res, next) => {
   }
 }
 
-// @desc    Get swarm by ID
+// @desc    Get swarm by ID (ACTUALIZADO para incluir MACs solicitadas)
 // @route   GET /swarms/:id
 // @access  Private (requires Bearer token)
 export const getSwarm = async (req, res, next) => {
@@ -103,7 +208,7 @@ export const getSwarm = async (req, res, next) => {
     const { userId, role } = req.user
     const { id } = req.params
 
-    // Check access permissions - CORREGIDO
+    // Check access permissions
     let whereClause = { swarmId: id }
     if (role !== 'Organization' && role !== 'Cluster manager') {
       whereClause.requesterId = userId
@@ -115,6 +220,24 @@ export const getSwarm = async (req, res, next) => {
         {
           model: Device,
           as: 'devices',
+          attributes: [
+            'deviceId',
+            'deviceName',
+            'deviceType',
+            'macAddress',
+            'firmwareVersion',
+            'lastIpAddress',
+            'location',
+            'isOnline',
+            'batteryLevel',
+            'role',
+            'status',
+            'assignedAt',
+            'assignedBy',
+            'removedAt',
+            'installationDate',
+            'lastSeen'
+          ],
         },
       ],
     })
@@ -123,21 +246,34 @@ export const getSwarm = async (req, res, next) => {
       return errorResponse(res, 'Swarm not found or access denied', 404)
     }
 
-    return successResponse(res, { swarm })
+    // NUEVO: Agregar información formateada de MACs solicitadas
+    const swarmData = swarm.toJSON()
+    if (swarmData.requestedMacs) {
+      swarmData.requestedMacsFormatted = swarm.getRequestedMacsFormatted()
+      swarmData.requestedMacsCount = swarmData.requestedMacs.length
+    }
+
+    return successResponse(res, { swarm: swarmData })
   } catch (error) {
     logger.error('Error getting swarm:', error)
     next(error)
   }
 }
 
-// @desc    Update swarm
+// @desc    Update swarm (ACTUALIZADO para manejar MACs solicitadas)
 // @route   PUT /swarms/:id
 // @access  Private (requires Bearer token)
 export const updateSwarm = async (req, res, next) => {
   try {
     const { userId, email, role } = req.user
     const { id } = req.params
-    const { name, description, maxDevices, location } = req.body
+    const { 
+      name, 
+      description, 
+      maxDevices, 
+      location, 
+      requestedMacs  // NUEVO: Permitir actualizar MACs solicitadas
+    } = req.body
 
     const swarm = await Swarm.findOne({ where: { swarmId: id } })
 
@@ -145,7 +281,7 @@ export const updateSwarm = async (req, res, next) => {
       return errorResponse(res, 'Swarm not found', 404)
     }
 
-    // Check ownership or permissions - CORREGIDO
+    // Check ownership or permissions
     if (role !== 'Organization' && role !== 'Cluster manager' && swarm.requesterId !== userId) {
       return errorResponse(
         res,
@@ -168,6 +304,56 @@ export const updateSwarm = async (req, res, next) => {
       allowedUpdates.maxDevices = maxDevices
     }
 
+    // NUEVO: Manejar actualización de MACs solicitadas
+    if (requestedMacs !== undefined && swarm.status === 'requested') {
+      // Solo permitir actualizar MACs si el swarm aún no ha sido asignado
+      if (requestedMacs === null) {
+        allowedUpdates.requestedMacs = null
+      } else if (Array.isArray(requestedMacs)) {
+        // Validar MACs
+        const macRegex = /^([0-9A-F]{2}[:-]){5}([0-9A-F]{2})$/i
+        for (const macEntry of requestedMacs) {
+          const macAddress = typeof macEntry === 'string' ? macEntry : macEntry.mac
+          if (!macAddress || !macRegex.test(macAddress)) {
+            return errorResponse(
+              res, 
+              `Invalid MAC address format: ${macAddress}`, 
+              400
+            )
+          }
+        }
+
+        // Verificar que no exceda maxDevices
+        const finalMaxDevices = maxDevices || swarm.maxDevices
+        if (requestedMacs.length > finalMaxDevices) {
+          return errorResponse(
+            res, 
+            `Cannot request more MACs (${requestedMacs.length}) than maxDevices (${finalMaxDevices})`, 
+            400
+          )
+        }
+
+        allowedUpdates.requestedMacs = requestedMacs.map(entry => {
+          if (typeof entry === 'string') {
+            return entry
+          } else {
+            return {
+              mac: entry.mac,
+              deviceName: entry.deviceName || null,
+              notes: entry.notes || null,
+              requestedAt: new Date()
+            }
+          }
+        })
+      }
+    } else if (requestedMacs !== undefined && swarm.status !== 'requested') {
+      return errorResponse(
+        res, 
+        'Cannot update requested MACs after swarm has been processed', 
+        400
+      )
+    }
+
     await swarm.update(allowedUpdates)
 
     logger.info(`Swarm updated: ${id} by user: ${userId} (${email})`)
@@ -179,65 +365,20 @@ export const updateSwarm = async (req, res, next) => {
   }
 }
 
-// @desc    Delete swarm
-// @route   DELETE /swarms/:id
-// @access  Private (requires Bearer token)
-export const deleteSwarm = async (req, res, next) => {
-  try {
-    const { userId, email, role } = req.user
-    const { id } = req.params
-
-    const swarm = await Swarm.findOne({ where: { swarmId: id } })
-
-    if (!swarm) {
-      return errorResponse(res, 'Swarm not found', 404)
-    }
-
-    // Check ownership or permissions - CORREGIDO
-    if (role !== 'Organization' && role !== 'Cluster manager' && swarm.requesterId !== userId) {
-      return errorResponse(
-        res,
-        'You are not authorized to delete this swarm',
-        403
-      )
-    }
-
-    // Only allow deletion if not active
-    if (swarm.status === 'active') {
-      return errorResponse(res, 'Cannot delete an active swarm', 400)
-    }
-
-    // Remove devices from swarm first (set swarmId to null)
-    await Device.update(
-      { swarmId: null },
-      { where: { swarmId: id } }
-    )
-
-    await swarm.destroy()
-
-    logger.info(`Swarm deleted: ${id} by user: ${userId} (${email})`)
-
-    return successResponse(res, null, 'Swarm deleted successfully')
-  } catch (error) {
-    logger.error('Error deleting swarm:', error)
-    next(error)
-  }
-}
-
-// @desc    Assign swarm to cluster manager
+// @desc    Assign swarm to cluster manager (ACTUALIZADO para manejar asignación automática)
 // @route   POST /swarms/:id/assign
 // @access  Private (requires Bearer token)
 export const assignSwarm = async (req, res, next) => {
   try {
     const { userId, email, role } = req.user
     const { id } = req.params
-    const { clusterManagerId } = req.body
+    const { clusterManagerId, autoAssignDevices = true } = req.body
 
     if (!clusterManagerId) {
       return errorResponse(res, 'clusterManagerId is required', 400)
     }
 
-    // Check permissions - CORREGIDO: Solo Project manager está restringido
+    // Check permissions
     if (role === 'Project manager') {
       return errorResponse(res, 'Insufficient permissions to assign swarms', 403)
     }
@@ -258,14 +399,230 @@ export const assignSwarm = async (req, res, next) => {
 
     await swarm.assignToClusterManager(clusterManagerId)
 
+    let assignmentResults = null
+
+    // NUEVO: Intentar asignar dispositivos automáticamente basado en las MACs solicitadas
+    if (autoAssignDevices && swarm.requestedMacs && swarm.requestedMacs.length > 0) {
+      try {
+        assignmentResults = await swarm.tryAssignRequestedDevices()
+        
+        logger.info(`Auto-assignment results for swarm ${id}:`, {
+          assigned: assignmentResults.assigned.length,
+          notFound: assignmentResults.notFound.length,
+          alreadyAssigned: assignmentResults.alreadyAssigned.length,
+          unavailable: assignmentResults.unavailable.length
+        })
+
+        // Log detalles para debugging
+        if (assignmentResults.notFound.length > 0) {
+          logger.warn(`Devices not found for swarm ${id}:`, assignmentResults.notFound)
+        }
+        if (assignmentResults.alreadyAssigned.length > 0) {
+          logger.warn(`Devices already assigned for swarm ${id}:`, assignmentResults.alreadyAssigned)
+        }
+        if (assignmentResults.unavailable.length > 0) {
+          logger.warn(`Devices unavailable for swarm ${id}:`, assignmentResults.unavailable)
+        }
+
+      } catch (assignmentError) {
+        logger.error(`Error during auto-assignment for swarm ${id}:`, assignmentError)
+        // No fallar la asignación del swarm por errores en la asignación automática
+        assignmentResults = {
+          assigned: [],
+          notFound: [],
+          alreadyAssigned: [],
+          unavailable: [],
+          error: assignmentError.message
+        }
+      }
+    }
+
     logger.info(`Swarm ${id} assigned to cluster manager: ${clusterManagerId} by ${email}`)
 
-    return successResponse(res, { swarm }, 'Swarm assigned successfully')
+    return successResponse(res, { 
+      swarm,
+      autoAssignmentResults: assignmentResults
+    }, 'Swarm assigned successfully')
   } catch (error) {
     logger.error('Error assigning swarm:', error)
     next(error)
   }
 }
+
+// NUEVO: Endpoint para intentar asignar dispositivos manualmente basado en MACs
+// @desc    Try to assign devices based on requested MACs
+// @route   POST /swarms/:id/assign-requested-devices
+// @access  Private (requires Bearer token)
+export const assignRequestedDevices = async (req, res, next) => {
+  try {
+    const { userId, email, role } = req.user
+    const { id } = req.params
+
+    // Check permissions
+    if (role === 'Project manager') {
+      return errorResponse(res, 'Insufficient permissions to assign devices', 403)
+    }
+
+    const swarm = await Swarm.findOne({ where: { swarmId: id } })
+
+    if (!swarm) {
+      return errorResponse(res, 'Swarm not found', 404)
+    }
+
+    if (!['assigned', 'active'].includes(swarm.status)) {
+      return errorResponse(
+        res,
+        'Swarm must be assigned or active to assign devices',
+        400
+      )
+    }
+
+    if (!swarm.requestedMacs || swarm.requestedMacs.length === 0) {
+      return errorResponse(res, 'No requested MACs found for this swarm', 400)
+    }
+
+    const results = await swarm.tryAssignRequestedDevices()
+
+    logger.info(`Manual device assignment for swarm ${id} by ${email}:`, results)
+
+    return successResponse(res, {
+      swarm: {
+        swarmId: swarm.swarmId,
+        swarmName: swarm.swarmName,
+        status: swarm.status
+      },
+      assignmentResults: results
+    }, 'Device assignment completed')
+
+  } catch (error) {
+    logger.error('Error assigning requested devices:', error)
+    next(error)
+  }
+}
+
+// NUEVO: Endpoint para obtener el estado de las MACs solicitadas
+// @desc    Get status of requested MACs
+// @route   GET /swarms/:id/requested-macs-status
+// @access  Private (requires Bearer token)
+export const getRequestedMacsStatus = async (req, res, next) => {
+  try {
+    const { userId, role } = req.user
+    const { id } = req.params
+
+    const swarm = await Swarm.findOne({ where: { swarmId: id } })
+
+    if (!swarm) {
+      return errorResponse(res, 'Swarm not found', 404)
+    }
+
+    // Verificar permisos
+    if (role !== 'Organization' && role !== 'Cluster manager' && swarm.requesterId !== userId) {
+      return errorResponse(res, 'Access denied', 403)
+    }
+
+    if (!swarm.requestedMacs || swarm.requestedMacs.length === 0) {
+      return successResponse(res, {
+        swarm: {
+          swarmId: swarm.swarmId,
+          swarmName: swarm.swarmName,
+          status: swarm.status
+        },
+        requestedMacs: [],
+        macsStatus: {
+          total: 0,
+          assigned: 0,
+          available: 0,
+          notFound: 0,
+          assignedElsewhere: 0
+        }
+      })
+    }
+
+    // Obtener las MACs solicitadas y verificar su estado
+    const requestedMacsFormatted = swarm.getRequestedMacsFormatted()
+    const macsStatus = {
+      total: requestedMacsFormatted.length,
+      assigned: 0,
+      available: 0,
+      notFound: 0,
+      assignedElsewhere: 0
+    }
+
+    const macsDetails = []
+
+    for (const macEntry of requestedMacsFormatted) {
+      const device = await Device.findOne({
+        where: { macAddress: macEntry.mac }
+      })
+
+      if (!device) {
+        // El dispositivo con esta MAC no existe en la base de datos
+        macsStatus.notFound++
+        macsDetails.push({
+          ...macEntry,
+          status: 'not_found',
+          deviceId: null,
+          deviceName: null,
+          currentSwarmId: null,
+          reason: 'Device not found in database'
+        })
+      } else if (device.swarmId === swarm.swarmId) {
+        // Ya está asignado a este swarm
+        macsStatus.assigned++
+        macsDetails.push({
+          ...macEntry,
+          status: 'assigned_to_this_swarm',
+          deviceId: device.deviceId,
+          deviceName: device.deviceName,
+          currentSwarmId: device.swarmId,
+          deviceStatus: device.status,
+          isOnline: device.isOnline,
+          batteryLevel: device.batteryLevel
+        })
+      } else if (device.swarmId && device.swarmId !== swarm.swarmId) {
+        // Está asignado a otro swarm
+        macsStatus.assignedElsewhere++
+        macsDetails.push({
+          ...macEntry,
+          status: 'assigned_elsewhere',
+          deviceId: device.deviceId,
+          deviceName: device.deviceName,
+          currentSwarmId: device.swarmId,
+          reason: 'Already assigned to another swarm'
+        })
+      } else {
+        // Dispositivo disponible (no asignado a ningún swarm)
+        macsStatus.available++
+        macsDetails.push({
+          ...macEntry,
+          status: 'available',
+          deviceId: device.deviceId,
+          deviceName: device.deviceName,
+          currentSwarmId: null,
+          deviceStatus: device.status,
+          isOnline: device.isOnline,
+          batteryLevel: device.batteryLevel
+        })
+      }
+    }
+
+    return successResponse(res, {
+      swarm: {
+        swarmId: swarm.swarmId,
+        swarmName: swarm.swarmName,
+        status: swarm.status
+      },
+      requestedMacs: macsDetails,
+      macsStatus
+    })
+
+  } catch (error) {
+    logger.error('Error getting requested MACs status:', error)
+    next(error)
+  }
+}
+
+// Métodos existentes continuados...
 
 // @desc    Activate swarm
 // @route   POST /swarms/:id/activate
@@ -275,7 +632,7 @@ export const activateSwarm = async (req, res, next) => {
     const { userId, email, role } = req.user
     const { id } = req.params
 
-    // Check permissions - CORREGIDO: Solo Project manager está restringido
+    // Check permissions
     if (role === 'Project manager') {
       return errorResponse(res, 'Insufficient permissions to activate swarms', 403)
     }
@@ -375,7 +732,7 @@ export const rejectSwarm = async (req, res, next) => {
     const { userId, email, role } = req.user
     const { id } = req.params
 
-    // Check permissions - CORREGIDO: Solo Project manager está restringido
+    // Check permissions
     if (role === 'Project manager') {
       return errorResponse(res, 'Insufficient permissions to reject swarms', 403)
     }
@@ -413,19 +770,21 @@ export const getSwarmDevices = async (req, res, next) => {
     const { userId, role } = req.user
     const { id } = req.params
 
-    // Check access permissions - CORREGIDO
-    let whereClause = { swarmId: id }
-    if (role !== 'Organization' && role !== 'Cluster manager') {
-      whereClause.requesterId = userId
-    }
-
-    const swarm = await Swarm.findOne({ where: whereClause })
+    // Check access permissions
+    const swarm = await Swarm.findOne({ 
+      where: { swarmId: id }
+    })
 
     if (!swarm) {
-      return errorResponse(res, 'Swarm not found or access denied', 404)
+      return errorResponse(res, 'Swarm not found', 404)
     }
 
-    // Buscar dispositivos directamente por swarmId
+    // Verificar permisos después de encontrar el swarm
+    if (role !== 'Organization' && role !== 'Cluster manager' && swarm.requesterId !== userId) {
+      return errorResponse(res, 'Access denied', 403)
+    }
+
+    // Buscar dispositivos usando el método del modelo
     const devices = await Device.findBySwarm(id)
 
     return successResponse(res, {
@@ -450,10 +809,11 @@ export const addDeviceToSwarm = async (req, res, next) => {
   try {
     const { userId, email, role } = req.user
     const { id } = req.params
-    const { deviceId } = req.body
+    const { deviceId, macAddress, deviceRole = 'sensor' } = req.body // CORRECCIÓN: Agregar opción de búsqueda por MAC
 
-    if (!deviceId) {
-      return errorResponse(res, 'deviceId is required', 400)
+    // NUEVO: Permitir búsqueda por deviceId o macAddress
+    if (!deviceId && !macAddress) {
+      return errorResponse(res, 'deviceId or macAddress is required', 400)
     }
 
     const swarm = await Swarm.findOne({ where: { swarmId: id } })
@@ -462,10 +822,16 @@ export const addDeviceToSwarm = async (req, res, next) => {
       return errorResponse(res, 'Swarm not found', 404)
     }
 
-    // Check if device exists
-    const device = await Device.findOne({ where: { deviceId } })
+    // NUEVO: Buscar dispositivo por ID o MAC
+    let device
+    if (deviceId) {
+      device = await Device.findOne({ where: { deviceId } })
+    } else {
+      device = await Device.findOne({ where: { macAddress } })
+    }
+
     if (!device) {
-      return errorResponse(res, 'Device not found', 404)
+      return errorResponse(res, `Device not found${macAddress ? ` with MAC: ${macAddress}` : ''}`, 404)
     }
 
     // Check if device is already assigned to another swarm
@@ -473,12 +839,9 @@ export const addDeviceToSwarm = async (req, res, next) => {
       return errorResponse(res, 'Device is already assigned to another swarm', 400)
     }
 
-    // Check device limit
-    const currentDeviceCount = await Device.count({
-      where: { swarmId: id }
-    })
-
-    if (currentDeviceCount >= swarm.maxDevices) {
+    // Usar el método del modelo actualizado para verificar si está lleno
+    const isFull = await swarm.isFull()
+    if (isFull) {
       return errorResponse(
         res,
         `Swarm has reached its limit of ${swarm.maxDevices} devices`,
@@ -486,10 +849,19 @@ export const addDeviceToSwarm = async (req, res, next) => {
       )
     }
 
-    // Assign device to swarm
+    // Usar el método del modelo actualizado
     await device.assignToSwarm(id)
+    
+    // Actualizar también los nuevos campos
+    await device.update({
+      role: deviceRole,
+      status: 'assigned',
+      assignedBy: userId,
+      assignedAt: new Date(),
+      removedAt: null
+    })
 
-    logger.info(`Device ${deviceId} added to swarm ${id} by user ${userId} (${email})`)
+    logger.info(`Device ${device.deviceId} (MAC: ${device.macAddress}) added to swarm ${id} by user ${userId} (${email})`)
 
     return successResponse(
       res,
@@ -519,8 +891,14 @@ export const removeDeviceFromSwarm = async (req, res, next) => {
       return errorResponse(res, 'Device not found in this swarm', 404)
     }
 
-    // Remove device from swarm
+    // Usar el método del modelo actualizado
     await device.removeFromSwarm()
+    
+    // Actualizar también los nuevos campos
+    await device.update({
+      status: 'unassigned',
+      removedAt: new Date()
+    })
 
     logger.info(`Device ${deviceId} removed from swarm ${id} by ${email}`)
 
@@ -531,7 +909,7 @@ export const removeDeviceFromSwarm = async (req, res, next) => {
   }
 }
 
-// @desc    Get swarm statistics
+// @desc    Get swarm statistics (ACTUALIZADO con estadísticas de MACs)
 // @route   GET /swarms/:id/stats
 // @access  Private (requires Bearer token)
 export const getSwarmStats = async (req, res, next) => {
@@ -539,22 +917,23 @@ export const getSwarmStats = async (req, res, next) => {
     const { userId, role } = req.user
     const { id } = req.params
 
-    // Check access permissions - CORREGIDO
-    let whereClause = { swarmId: id }
-    if (role !== 'Organization' && role !== 'Cluster manager') {
-      whereClause.requesterId = userId
-    }
-
-    const swarm = await Swarm.findOne({ where: whereClause })
+    // Verificar permisos correctamente
+    const swarm = await Swarm.findOne({ where: { swarmId: id } })
 
     if (!swarm) {
-      return errorResponse(res, 'Swarm not found or access denied', 404)
+      return errorResponse(res, 'Swarm not found', 404)
+    }
+
+    // Verificar permisos después de encontrar el swarm
+    if (role !== 'Organization' && role !== 'Cluster manager' && swarm.requesterId !== userId) {
+      return errorResponse(res, 'Access denied', 403)
     }
 
     const devices = await Device.findAll({
       where: { swarmId: id },
     })
 
+    // Estadísticas mejoradas con los nuevos campos
     const stats = {
       totalDevices: devices.length,
       onlineDevices: devices.filter((d) => d.isOnline).length,
@@ -563,11 +942,53 @@ export const getSwarmStats = async (req, res, next) => {
         acc[device.deviceType] = (acc[device.deviceType] || 0) + 1
         return acc
       }, {}),
+      devicesByRole: devices.reduce((acc, device) => {
+        acc[device.role || 'sensor'] = (acc[device.role || 'sensor'] || 0) + 1
+        return acc
+      }, {}),
+      devicesByStatus: devices.reduce((acc, device) => {
+        acc[device.status || 'assigned'] = (acc[device.status || 'assigned'] || 0) + 1
+        return acc
+      }, {}),
       averageBatteryLevel: devices.length > 0 
         ? Math.round(devices.reduce((sum, d) => sum + (d.batteryLevel || 0), 0) / devices.length)
         : 0,
       lowBatteryDevices: devices.filter((d) => d.batteryLevel && d.batteryLevel < 20).length,
       utilizationPercentage: Math.round((devices.length / swarm.maxDevices) * 100),
+      recentlyAssigned: devices.filter((d) => {
+        if (!d.assignedAt) return false
+        const dayAgo = new Date(Date.now() - 24 * 60 * 60 * 1000)
+        return new Date(d.assignedAt) > dayAgo
+      }).length,
+    }
+
+    // NUEVO: Estadísticas de MACs solicitadas
+    const macsStats = {
+      totalRequested: 0,
+      assignedFromRequested: 0,
+      pendingAssignment: 0,
+      notFound: 0
+    }
+
+    if (swarm.requestedMacs && swarm.requestedMacs.length > 0) {
+      macsStats.totalRequested = swarm.requestedMacs.length
+      
+      for (const macEntry of swarm.requestedMacs) {
+        const macAddress = typeof macEntry === 'string' ? macEntry : macEntry.mac
+        const device = devices.find(d => d.macAddress === macAddress)
+        
+        if (device) {
+          macsStats.assignedFromRequested++
+        } else {
+          // Verificar si el dispositivo existe pero no está asignado
+          const existingDevice = await Device.findOne({ where: { macAddress } })
+          if (existingDevice) {
+            macsStats.pendingAssignment++
+          } else {
+            macsStats.notFound++
+          }
+        }
+      }
     }
 
     return successResponse(res, {
@@ -578,9 +999,61 @@ export const getSwarmStats = async (req, res, next) => {
         maxDevices: swarm.maxDevices,
       },
       stats,
+      macsStats
     })
   } catch (error) {
     logger.error('Error getting swarm statistics:', error)
+    next(error)
+  }
+}
+
+// @desc    Delete swarm
+// @route   DELETE /swarms/:id
+// @access  Private (requires Bearer token)
+export const deleteSwarm = async (req, res, next) => {
+  try {
+    const { userId, email, role } = req.user
+    const { id } = req.params
+
+    const swarm = await Swarm.findOne({ where: { swarmId: id } })
+
+    if (!swarm) {
+      return errorResponse(res, 'Swarm not found', 404)
+    }
+
+    // Check ownership or permissions
+    if (role !== 'Organization' && role !== 'Cluster manager' && swarm.requesterId !== userId) {
+      return errorResponse(
+        res,
+        'You are not authorized to delete this swarm',
+        403
+      )
+    }
+
+    // Only allow deletion if not active
+    if (swarm.status === 'active') {
+      return errorResponse(res, 'Cannot delete an active swarm', 400)
+    }
+
+    // Remove devices from swarm first y marcar como removidos
+    const devicesInSwarm = await Device.findAll({ where: { swarmId: id } })
+    
+    for (const device of devicesInSwarm) {
+      await device.removeFromSwarm() // Usa el método del modelo
+      // También marcar como removido en el nuevo esquema
+      await device.update({
+        removedAt: new Date(),
+        status: 'unassigned'
+      })
+    }
+
+    await swarm.destroy()
+
+    logger.info(`Swarm deleted: ${id} by user: ${userId} (${email})`)
+
+    return successResponse(res, null, 'Swarm deleted successfully')
+  } catch (error) {
+    logger.error('Error deleting swarm:', error)
     next(error)
   }
 }

--- a/backend/swarms/src/models/Device.js
+++ b/backend/swarms/src/models/Device.js
@@ -30,7 +30,7 @@ class Device extends Model {
           allowNull: true,
           field: 'mac_address',
           validate: {
-            is: /^([0-9A-F]{2}[:-]){5}([0-9A-F]{2})$/i, // Formato MAC address
+            is: /^([0-9A-F]{2}[:-]){5}([0-9A-F]{2})$/i,
           },
         },
         firmwareVersion: {
@@ -39,7 +39,8 @@ class Device extends Model {
           field: 'firmware_version',
         },
         lastIpAddress: {
-          type: DataTypes.INET,
+          // Cambiado de INET a STRING(50) para coincidir con tu tabla
+          type: DataTypes.STRING(50),
           allowNull: true,
           field: 'last_ip_address',
         },
@@ -80,11 +81,46 @@ class Device extends Model {
             max: 100,
           },
         },
+        // CAMPOS FALTANTES QUE TIENES EN TU TABLA:
+        role: {
+          type: DataTypes.STRING(50),
+          allowNull: true,
+          defaultValue: 'sensor',
+        },
+        assignedAt: {
+          type: DataTypes.DATE, // timestamp without time zone
+          defaultValue: DataTypes.NOW,
+          allowNull: true,
+          field: 'assigned_at',
+        },
+        assignedBy: {
+          type: DataTypes.INTEGER,
+          allowNull: true,
+          field: 'assigned_by',
+          // Podrías agregar una referencia si tienes una tabla de usuarios
+          // references: {
+          //   model: 'users',
+          //   key: 'id',
+          // },
+        },
+        removedAt: {
+          type: DataTypes.DATE, // timestamp without time zone
+          allowNull: true,
+          field: 'removed_at',
+        },
+        status: {
+          type: DataTypes.STRING(20),
+          defaultValue: 'assigned',
+          allowNull: true,
+          validate: {
+            isIn: [['assigned', 'unassigned', 'maintenance', 'inactive']], // Ajusta según tus estados
+          },
+        },
       },
       {
         sequelize,
         modelName: 'Device',
-        tableName: 'esp32_devices', // Tabla esp32_devices
+        tableName: 'esp32_devices',
         timestamps: true,
         createdAt: 'created_at',
         updatedAt: 'updated_at',
@@ -99,9 +135,16 @@ class Device extends Model {
       as: 'swarm',
       onDelete: 'SET NULL',
     })
+    
+    // Si tienes una tabla de usuarios, podrías agregar:
+    // this.belongsTo(models.User, {
+    //   foreignKey: 'assignedBy',
+    //   as: 'assignedByUser',
+    //   onDelete: 'SET NULL',
+    // })
   }
 
-  // Instance methods
+  // Métodos de instancia existentes
   async setOnline() {
     this.isOnline = true
     this.lastSeen = new Date()
@@ -139,7 +182,37 @@ class Device extends Model {
     return this
   }
 
-  // Static methods
+  // NUEVOS MÉTODOS PARA LOS CAMPOS AGREGADOS:
+  async assignDevice(assignedBy, role = 'sensor') {
+    this.status = 'assigned'
+    this.assignedBy = assignedBy
+    this.assignedAt = new Date()
+    this.role = role
+    this.removedAt = null
+    await this.save()
+    return this
+  }
+
+  async removeDevice() {
+    this.status = 'unassigned'
+    this.removedAt = new Date()
+    await this.save()
+    return this
+  }
+
+  async setMaintenance() {
+    this.status = 'maintenance'
+    await this.save()
+    return this
+  }
+
+  async setActive() {
+    this.status = 'assigned'
+    await this.save()
+    return this
+  }
+
+  // Métodos estáticos existentes
   static async findOnline() {
     return await this.findAll({
       where: { isOnline: true },
@@ -190,7 +263,36 @@ class Device extends Model {
     })
   }
 
-  // Método para heartbeat (mantener dispositivo vivo)
+  // NUEVOS MÉTODOS ESTÁTICOS PARA LOS CAMPOS AGREGADOS:
+  static async findByStatus(status) {
+    return await this.findAll({
+      where: { status },
+    })
+  }
+
+  static async findByRole(role) {
+    return await this.findAll({
+      where: { role },
+    })
+  }
+
+  static async findAssignedBy(userId) {
+    return await this.findAll({
+      where: { assignedBy: userId },
+    })
+  }
+
+  static async findRemovedDevices() {
+    return await this.findAll({
+      where: {
+        removedAt: {
+          [this.sequelize.Sequelize.Op.ne]: null,
+        },
+      },
+    })
+  }
+
+  // Método para heartbeat actualizado
   async heartbeat(batteryLevel = null, ipAddress = null) {
     this.isOnline = true
     this.lastSeen = new Date()

--- a/backend/swarms/src/models/Swarm.js
+++ b/backend/swarms/src/models/Swarm.js
@@ -55,23 +55,56 @@ class Swarm extends Model {
             isIn: [['requested', 'assigned', 'active', 'paused', 'completed', 'rejected']],
           },
         },
+        // NUEVO CAMPO: MACs solicitadas
+        requestedMacs: {
+          type: DataTypes.JSONB,
+          allowNull: true,
+          field: 'requested_macs',
+          validate: {
+            isValidMacsArray(value) {
+              if (value !== null && value !== undefined) {
+                if (!Array.isArray(value)) {
+                  throw new Error('requestedMacs must be an array')
+                }
+                
+                // Validar cada MAC address en el array
+                const macRegex = /^([0-9A-F]{2}[:-]){5}([0-9A-F]{2})$/i
+                for (const macEntry of value) {
+                  if (typeof macEntry === 'string') {
+                    // Si es solo un string (MAC), validarlo
+                    if (!macRegex.test(macEntry)) {
+                      throw new Error(`Invalid MAC address format: ${macEntry}`)
+                    }
+                  } else if (typeof macEntry === 'object' && macEntry !== null) {
+                    // Si es un objeto con MAC y metadata
+                    if (!macEntry.mac || !macRegex.test(macEntry.mac)) {
+                      throw new Error(`Invalid MAC address format in object: ${macEntry.mac}`)
+                    }
+                  } else {
+                    throw new Error('Each MAC entry must be a string or object')
+                  }
+                }
+              }
+            }
+          }
+        },
         assignedAt: {
-          type: DataTypes.DATE,
+          type: 'TIMESTAMP WITHOUT TIME ZONE',
           allowNull: true,
           field: 'assigned_at',
         },
         activatedAt: {
-          type: DataTypes.DATE,
+          type: 'TIMESTAMP WITHOUT TIME ZONE',
           allowNull: true,
           field: 'activated_at',
         },
         completedAt: {
-          type: DataTypes.DATE,
+          type: 'TIMESTAMP WITHOUT TIME ZONE',
           allowNull: true,
           field: 'completed_at',
         },
         lastActivity: {
-          type: DataTypes.DATE,
+          type: 'TIMESTAMP WITHOUT TIME ZONE',
           allowNull: true,
           field: 'last_activity',
         },
@@ -89,7 +122,7 @@ class Swarm extends Model {
       {
         sequelize,
         modelName: 'Swarm',
-        tableName: 'device_swarms', // Tabla device_swarms
+        tableName: 'device_swarms',
         timestamps: true,
         createdAt: 'created_at',
         updatedAt: 'updated_at',
@@ -106,7 +139,7 @@ class Swarm extends Model {
     })
   }
 
-  // Instance methods
+  // Instance methods existentes
   async assignToClusterManager(clusterManagerId) {
     this.clusterManagerId = clusterManagerId
     this.status = 'assigned'
@@ -151,7 +184,194 @@ class Swarm extends Model {
     return this
   }
 
-  // Class methods
+  // NUEVOS MÉTODOS para manejar MACs solicitadas
+  async addRequestedMac(macAddress, deviceName = null, notes = null) {
+    const currentMacs = this.requestedMacs || []
+    
+    // Verificar si la MAC ya existe
+    const macExists = currentMacs.some(entry => {
+      return typeof entry === 'string' ? entry === macAddress : entry.mac === macAddress
+    })
+    
+    if (macExists) {
+      throw new Error(`MAC address ${macAddress} already exists in requested MACs`)
+    }
+    
+    const newEntry = deviceName || notes ? 
+      { mac: macAddress, deviceName, notes, requestedAt: new Date() } : 
+      macAddress
+    
+    this.requestedMacs = [...currentMacs, newEntry]
+    await this.save()
+    return this
+  }
+
+  async removeRequestedMac(macAddress) {
+    if (!this.requestedMacs) return this
+    
+    this.requestedMacs = this.requestedMacs.filter(entry => {
+      return typeof entry === 'string' ? entry !== macAddress : entry.mac !== macAddress
+    })
+    
+    await this.save()
+    return this
+  }
+
+  async updateRequestedMacs(macsArray) {
+    this.requestedMacs = macsArray
+    await this.save()
+    return this
+  }
+
+  // Método para obtener las MACs en formato consistente
+  getRequestedMacsFormatted() {
+    if (!this.requestedMacs) return []
+    
+    return this.requestedMacs.map(entry => {
+      if (typeof entry === 'string') {
+        return {
+          mac: entry,
+          deviceName: null,
+          notes: null,
+          requestedAt: this.createdAt
+        }
+      }
+      return {
+        mac: entry.mac,
+        deviceName: entry.deviceName || null,
+        notes: entry.notes || null,
+        requestedAt: entry.requestedAt || this.createdAt
+      }
+    })
+  }
+
+  // Método para intentar asignar dispositivos basado en las MACs solicitadas
+  async tryAssignRequestedDevices() {
+    if (!this.requestedMacs || this.requestedMacs.length === 0) {
+      return { assigned: [], notFound: [], alreadyAssigned: [], unavailable: [] }
+    }
+
+    const results = {
+      assigned: [],
+      notFound: [],
+      alreadyAssigned: [],
+      unavailable: [] // Dispositivos que existen pero no están disponibles
+    }
+
+    // Obtener las MACs solicitadas
+    const requestedMacs = this.requestedMacs.map(entry => 
+      typeof entry === 'string' ? entry : entry.mac
+    )
+
+    // Buscar dispositivos por MAC
+    const Device = this.sequelize.models.Device
+    
+    for (const macAddress of requestedMacs) {
+      try {
+        // CORREGIDO: Buscar dispositivo por MAC address
+        const device = await Device.findOne({
+          where: { macAddress: macAddress }
+        })
+
+        if (!device) {
+          // El dispositivo con esta MAC no existe en la base de datos
+          results.notFound.push({
+            mac: macAddress,
+            reason: 'Device not found in database'
+          })
+          continue
+        }
+
+        // CORREGIDO: Verificar si el dispositivo ya está asignado a otro swarm
+        if (device.swarmId && device.swarmId !== this.swarmId) {
+          results.alreadyAssigned.push({
+            mac: macAddress,
+            deviceId: device.deviceId,
+            deviceName: device.deviceName,
+            currentSwarmId: device.swarmId,
+            reason: 'Already assigned to another swarm'
+          })
+          continue
+        }
+
+        // Si ya está asignado a este mismo swarm, skipear
+        if (device.swarmId === this.swarmId) {
+          results.assigned.push({
+            mac: macAddress,
+            deviceId: device.deviceId,
+            deviceName: device.deviceName,
+            reason: 'Already assigned to this swarm'
+          })
+          continue
+        }
+
+        // CORREGIDO: Verificar si el dispositivo está disponible (no asignado a ningún swarm)
+        if (device.swarmId !== null) {
+          results.unavailable.push({
+            mac: macAddress,
+            deviceId: device.deviceId,
+            deviceName: device.deviceName,
+            currentSwarmId: device.swarmId,
+            reason: 'Device is not available'
+          })
+          continue
+        }
+
+        // Verificar si el swarm no está lleno
+        const isFull = await this.isFull()
+        if (isFull) {
+          results.unavailable.push({
+            mac: macAddress,
+            deviceId: device.deviceId,
+            deviceName: device.deviceName,
+            reason: 'Swarm is full'
+          })
+          break // Detener si el swarm está lleno
+        }
+
+        // CORREGIDO: Asignar dispositivo disponible al swarm
+        await device.assignToSwarm(this.swarmId)
+        await device.update({
+          role: 'sensor', // Rol por defecto
+          status: 'assigned',
+          assignedBy: this.clusterManagerId, // Asignado por el cluster manager
+          assignedAt: new Date(),
+          removedAt: null
+        })
+
+        results.assigned.push({
+          mac: macAddress,
+          deviceId: device.deviceId,
+          deviceName: device.deviceName,
+          reason: 'Successfully assigned'
+        })
+
+      } catch (error) {
+        console.error(`Error processing MAC ${macAddress}:`, error)
+        results.notFound.push({
+          mac: macAddress,
+          reason: `Database error: ${error.message}`
+        })
+      }
+    }
+
+    return results
+  }
+
+  // Métodos existentes
+  async getDeviceCount() {
+    return await this.sequelize.models.Device.count({
+      where: { swarmId: this.swarmId }
+    })
+  }
+
+  async isFull() {
+    if (!this.maxDevices) return false
+    const deviceCount = await this.getDeviceCount()
+    return deviceCount >= this.maxDevices
+  }
+
+  // Class methods existentes
   static async findByStatus(status) {
     return await this.findAll({
       where: { status },
@@ -191,6 +411,29 @@ class Swarm extends Model {
   static async findActive() {
     return await this.findAll({
       where: { isActive: true },
+    })
+  }
+
+  static async findByClusterManager(clusterManagerId) {
+    return await this.findAll({
+      where: { clusterManagerId },
+      include: [
+        {
+          model: this.sequelize.models.Device,
+          as: 'devices',
+        },
+      ],
+    })
+  }
+
+  // NUEVO: Método para buscar swarms que tienen MACs solicitadas específicas
+  static async findByRequestedMac(macAddress) {
+    return await this.findAll({
+      where: {
+        requestedMacs: {
+          [this.sequelize.Sequelize.Op.contains]: [macAddress]
+        }
+      }
     })
   }
 }

--- a/frontend/src/modules/swarms/pages/SelectSwarmRequests.jsx
+++ b/frontend/src/modules/swarms/pages/SelectSwarmRequests.jsx
@@ -19,6 +19,8 @@ export default function SelectSwarmRequests() {
   const [selectedRequest, setSelectedRequest] = useState(null);
   const [successMessage, setSuccessMessage] = useState("");
   const [assigning, setAssigning] = useState(false);
+  // NUEVO: Estado para mostrar detalles de asignación
+  const [assignmentResults, setAssignmentResults] = useState(null);
 
   // Function to load swarm requests using the service
   const loadSwarmRequests = async () => {
@@ -61,24 +63,33 @@ export default function SelectSwarmRequests() {
     return 0;
   });
 
+  // ACTUALIZADO: Manejo de asignación con resultados de auto-asignación
   const handleAddToCatalog = async (req) => {
     setAssigning(true);
     
     try {
       // Use the assignSwarmToMe service method
       console.log("SWARM ID", req)
-      await swarmService.assignSwarmToMe(req.id);
+      const result = await swarmService.assignSwarmToMe(req.id);
+      
+      // NUEVO: Guardar resultados de auto-asignación para mostrar
+      if (result.autoAssignmentResults) {
+        setAssignmentResults({
+          swarmName: req.name,
+          results: result.autoAssignmentResults
+        });
+      }
       
       // Remove the request from the local list since it's now assigned
       setRequests(prevRequests => 
         prevRequests.filter(request => request.id !== req.id)
       );
       
-      setSuccessMessage(`'${req.name}' added to your catalog successfully!`);
+      setSuccessMessage(`'${req.name}' assigned to you successfully!`);
       setSelectedRequest(null);
     } catch (error) {
       console.error('Error assigning swarm:', error);
-      setSuccessMessage(`Error adding '${req.name}' to your catalog. Please try again.`);
+      setSuccessMessage(`Error assigning '${req.name}'. Please try again.`);
     } finally {
       setAssigning(false);
     }
@@ -118,7 +129,7 @@ export default function SelectSwarmRequests() {
             Pending Swarm Requests ({sortedRequests.length})
           </h1>
           <p className="text-gray-600 dark:text-gray-400 text-lg">
-            Review and add swarm requests to your catalog.
+            Review and assign swarm requests to your management.
           </p>
         </div>
         
@@ -215,7 +226,7 @@ export default function SelectSwarmRequests() {
           </div>
         </div>
       ) : (
-        /* Swarm Requests Grid - Mejorado para consistencia */
+        /* Swarm Requests Grid - ACTUALIZADO con información de MACs */
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
           {sortedRequests.map((req) => (
             <div
@@ -255,6 +266,52 @@ export default function SelectSwarmRequests() {
                       {req.maxDevices}
                     </span>
                   </div>
+                  
+                  {/* NUEVO: Mostrar información de MACs solicitadas */}
+                  {req.requestedMacsCount > 0 && (
+                    <div className="mt-3 pt-3 border-t border-gray-200 dark:border-gray-600">
+                      <div className="flex justify-between items-center">
+                        <span className="text-gray-500 dark:text-gray-500">Requested devices:</span>
+                        <span className="text-blue-600 dark:text-blue-400 font-medium">
+                          {req.requestedMacsCount} device{req.requestedMacsCount !== 1 ? 's' : ''}
+                        </span>
+                      </div>
+                      
+                      {/* NUEVO: Vista previa de las primeras MACs */}
+                      {req.requestedMacs && req.requestedMacs.length > 0 && (
+                        <div className="mt-2">
+                          <div className="text-xs text-gray-400 dark:text-gray-500 mb-1">
+                            MAC addresses requested:
+                          </div>
+                          <div className="space-y-1 max-h-20 overflow-y-auto">
+                            {req.requestedMacs.slice(0, 3).map((macEntry, index) => {
+                              const mac = typeof macEntry === 'string' ? macEntry : macEntry.mac;
+                              const deviceName = typeof macEntry === 'object' ? macEntry.deviceName : null;
+                              
+                              return (
+                                <div key={index} className="text-xs">
+                                  <span className="font-mono text-gray-600 dark:text-gray-400">
+                                    {mac}
+                                  </span>
+                                  {deviceName && (
+                                    <span className="ml-2 text-gray-500 dark:text-gray-500">
+                                      ({deviceName})
+                                    </span>
+                                  )}
+                                </div>
+                              );
+                            })}
+                            
+                            {req.requestedMacs.length > 3 && (
+                              <div className="text-xs text-gray-400 dark:text-gray-500 italic">
+                                +{req.requestedMacs.length - 3} more device{req.requestedMacs.length - 3 !== 1 ? 's' : ''}
+                              </div>
+                            )}
+                          </div>
+                        </div>
+                      )}
+                    </div>
+                  )}
                 </div>
               </div>
               
@@ -266,11 +323,11 @@ export default function SelectSwarmRequests() {
                 {assigning ? (
                   <span className="flex items-center justify-center gap-2">
                     <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-white"></div>
-                    Adding...
+                    Assigning...
                   </span>
                 ) : (
                   <span className="flex items-center justify-center gap-2">
-                    ➕ Add to my catalog
+                    ➕ Assign to me
                   </span>
                 )}
               </button>
@@ -279,17 +336,140 @@ export default function SelectSwarmRequests() {
         </div>
       )}
 
-      {/* Confirmation modal */}
+      {/* NUEVO: Modal de confirmación actualizado con información de MACs */}
       <ConfirmationModal
         isOpen={!!selectedRequest}
         onClose={() => setSelectedRequest(null)}
         onConfirm={() => handleAddToCatalog(selectedRequest)}
-        title={`Add "${selectedRequest?.name}" to your catalog?`}
-        message="This will add the swarm request to your personal catalog for management."
-        confirmText={assigning ? "Adding..." : "Confirm"}
+        title={`Assign "${selectedRequest?.name}" to your management?`}
+        message={
+          <div className="space-y-3">
+            <p>This will assign the swarm request to you for management.</p>
+            
+            {selectedRequest?.requestedMacsCount > 0 && (
+              <div className="bg-blue-50 dark:bg-blue-900/20 p-3 rounded-lg">
+                <div className="text-sm text-blue-800 dark:text-blue-300">
+                  <strong>📱 Requested Devices:</strong> {selectedRequest.requestedMacsCount} device{selectedRequest.requestedMacsCount !== 1 ? 's' : ''}
+                </div>
+                <div className="text-xs text-blue-600 dark:text-blue-400 mt-1">
+                  The system will automatically attempt to assign the requested devices to this swarm.
+                </div>
+              </div>
+            )}
+          </div>
+        }
+        confirmText={assigning ? "Assigning..." : "Confirm Assignment"}
         cancelText="Cancel"
         isLoading={assigning}
       />
+
+      {/* NUEVO: Modal para mostrar resultados de auto-asignación */}
+      {assignmentResults && (
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50">
+          <div className="bg-white dark:bg-gray-800 rounded-lg shadow-xl max-w-2xl w-full max-h-[80vh] overflow-y-auto">
+            <div className="p-6">
+              <div className="flex justify-between items-start mb-4">
+                <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
+                  Device Assignment Results - {assignmentResults.swarmName}
+                </h3>
+                <button
+                  onClick={() => setAssignmentResults(null)}
+                  className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
+                >
+                  ✕
+                </button>
+              </div>
+              
+              <div className="space-y-4">
+                {/* Dispositivos asignados exitosamente */}
+                {assignmentResults.results.assigned?.length > 0 && (
+                  <div className="bg-green-50 dark:bg-green-900/20 p-4 rounded-lg">
+                    <h4 className="font-medium text-green-800 dark:text-green-300 mb-2">
+                      ✅ Successfully Assigned ({assignmentResults.results.assigned.length})
+                    </h4>
+                    <div className="space-y-1">
+                      {assignmentResults.results.assigned.map((device, index) => (
+                        <div key={index} className="text-sm text-green-700 dark:text-green-400">
+                          <span className="font-mono">{device.mac}</span>
+                          {device.deviceName && (
+                            <span className="ml-2">- {device.deviceName}</span>
+                          )}
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                )}
+                
+                {/* Dispositivos no encontrados */}
+                {assignmentResults.results.notFound?.length > 0 && (
+                  <div className="bg-red-50 dark:bg-red-900/20 p-4 rounded-lg">
+                    <h4 className="font-medium text-red-800 dark:text-red-300 mb-2">
+                      ❌ Not Found ({assignmentResults.results.notFound.length})
+                    </h4>
+                    <div className="space-y-1">
+                      {assignmentResults.results.notFound.map((item, index) => (
+                        <div key={index} className="text-sm text-red-700 dark:text-red-400">
+                          <span className="font-mono">{item.mac || item}</span>
+                          {item.reason && (
+                            <span className="ml-2 text-xs">- {item.reason}</span>
+                          )}
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                )}
+                
+                {/* Dispositivos ya asignados a otros swarms */}
+                {assignmentResults.results.alreadyAssigned?.length > 0 && (
+                  <div className="bg-yellow-50 dark:bg-yellow-900/20 p-4 rounded-lg">
+                    <h4 className="font-medium text-yellow-800 dark:text-yellow-300 mb-2">
+                      ⚠️ Already Assigned Elsewhere ({assignmentResults.results.alreadyAssigned.length})
+                    </h4>
+                    <div className="space-y-1">
+                      {assignmentResults.results.alreadyAssigned.map((device, index) => (
+                        <div key={index} className="text-sm text-yellow-700 dark:text-yellow-400">
+                          <span className="font-mono">{device.mac}</span>
+                          {device.deviceName && (
+                            <span className="ml-2">- {device.deviceName}</span>
+                          )}
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                )}
+                
+                {/* Dispositivos no disponibles */}
+                {assignmentResults.results.unavailable?.length > 0 && (
+                  <div className="bg-gray-50 dark:bg-gray-700/20 p-4 rounded-lg">
+                    <h4 className="font-medium text-gray-800 dark:text-gray-300 mb-2">
+                      ⏸️ Unavailable ({assignmentResults.results.unavailable.length})
+                    </h4>
+                    <div className="space-y-1">
+                      {assignmentResults.results.unavailable.map((device, index) => (
+                        <div key={index} className="text-sm text-gray-700 dark:text-gray-400">
+                          <span className="font-mono">{device.mac}</span>
+                          {device.reason && (
+                            <span className="ml-2 text-xs">- {device.reason}</span>
+                          )}
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                )}
+              </div>
+              
+              <div className="mt-6 flex justify-end">
+                <button
+                  onClick={() => setAssignmentResults(null)}
+                  className="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg font-medium transition-colors"
+                >
+                  Close
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
 
       {/* Success feedback */}
       <SuccessToast

--- a/frontend/src/modules/swarms/pages/SwarmDetail.jsx
+++ b/frontend/src/modules/swarms/pages/SwarmDetail.jsx
@@ -27,7 +27,9 @@ export default function SwarmDetail() {
     setError(false)
 
     try {
+      console.log("HOLAAAA")
       const data = await swarmService.getSwarmDetailWithDevices(id)
+      console.log(data)
       setSwarm(data)
     } catch (error) {
       console.error('Error loading swarm detail:', error)

--- a/frontend/src/modules/swarms/services/SwarmService.js
+++ b/frontend/src/modules/swarms/services/SwarmService.js
@@ -22,6 +22,9 @@ class SwarmService {
     if (filters.limit) queryParams.append('limit', filters.limit);
     if (filters.offset) queryParams.append('offset', filters.offset);
     
+    // NUEVO: Incluir MACs si se necesitan (útil para swarms solicitados)
+    if (filters.includeMacs) queryParams.append('includeMacs', 'true');
+    
     if (queryParams.toString()) {
       endpoint += `?${queryParams.toString()}`;
     }
@@ -47,6 +50,10 @@ class SwarmService {
       activatedAt: s.activatedAt,
       location: s.location,
       isActive: s.isActive,
+      // NUEVO: MACs solicitadas (solo para swarms con status 'requested')
+      requestedMacs: s.requestedMacs || null,
+      requestedMacsCount: s.requestedMacsCount || 0,
+      requestedMacsFormatted: s.requestedMacsFormatted || null,
     })) || []);
   }
 
@@ -65,7 +72,8 @@ class SwarmService {
    * @returns {Promise<Array>} Array of pending requests
    */
   async getSwarmRequests() {
-    return this.getSwarms({ status: 'requested' });
+    // NUEVO: Incluir MACs para ver las solicitudes completas
+    return this.getSwarms({ status: 'requested', includeMacs: true });
   }
 
   /**
@@ -99,6 +107,10 @@ class SwarmService {
           activatedAt: swarm.activatedAt,
           location: swarm.location,
           isActive: swarm.isActive,
+          // NUEVO: MACs solicitadas y formateadas
+          requestedMacs: swarm.requestedMacs || null,
+          requestedMacsCount: swarm.requestedMacsCount || 0,
+          requestedMacsFormatted: swarm.requestedMacsFormatted || null,
         };
       }
       
@@ -108,7 +120,7 @@ class SwarmService {
       console.error('Failed to fetch swarm directly:', error);
       // Fallback: Get all swarms and find the specific one
       try {
-        const allSwarms = await this.getSwarms();
+        const allSwarms = await this.getSwarms({ includeMacs: true });
         const targetSwarm = allSwarms.find(s => s.id === swarmId);
         
         if (targetSwarm) {
@@ -153,6 +165,11 @@ class SwarmService {
         lastSeen: device.lastSeen,
         macAddress: device.macAddress,
         location: device.location,
+        // NUEVO: Campos adicionales del dispositivo
+        role: device.role,
+        deviceStatus: device.status,
+        assignedAt: device.assignedAt,
+        assignedBy: device.assignedBy,
       }));
       
       return {
@@ -170,21 +187,66 @@ class SwarmService {
   }
 
   /**
+   * NUEVO: Get status of requested MACs for a swarm
+   * Useful for showing detailed MAC assignment status in swarm requests
+   * @param {string} swarmId - The swarm ID to fetch MAC status for
+   * @returns {Promise<Object>} MAC status details
+   */
+  async getRequestedMacsStatus(swarmId) {
+    try {
+      const response = await apiService.get(`/swarms/${swarmId}/requested-macs-status`);
+      return {
+        swarm: response.data?.swarm,
+        requestedMacs: response.data?.requestedMacs || [],
+        macsStatus: response.data?.macsStatus || {},
+      };
+    } catch (error) {
+      throw new Error(`Failed to get MAC status: ${error.response?.data?.message || error.message}`);
+    }
+  }
+
+  /**
+   * NUEVO: Manually assign devices based on requested MACs
+   * Used when auto-assignment didn't work completely
+   * @param {string} swarmId - The swarm ID to assign devices to
+   * @returns {Promise<Object>} Assignment results
+   */
+  async assignRequestedDevices(swarmId) {
+    try {
+      const response = await apiService.post(`/swarms/${swarmId}/assign-requested-devices`);
+      return {
+        swarm: response.data?.swarm,
+        assignmentResults: response.data?.assignmentResults,
+      };
+    } catch (error) {
+      throw new Error(`Failed to assign requested devices: ${error.response?.data?.message || error.message}`);
+    }
+  }
+
+  /**
    * Create a new swarm
    * @param {Object} swarmData - Swarm data to create
    * @param {string} swarmData.name - Swarm name
    * @param {string} swarmData.description - Swarm description
    * @param {number} swarmData.maxDevices - Maximum number of devices
    * @param {number} swarmData.requesterId - ID of the requesting user
+   * @param {Array} swarmData.requestedMacs - Optional array of requested MAC addresses
    * @returns {Promise<Object>} Created swarm data
    */
   async createSwarm(swarmData) {
-    const response = await apiService.post('/swarms', {
+    const payload = {
       name: swarmData.name,
       description: swarmData.description || "",
       maxDevices: swarmData.maxDevices,
       requesterId: swarmData.requesterId,
-    });
+    };
+    
+    // NUEVO: Incluir MACs solicitadas si se proporcionan
+    if (swarmData.requestedMacs && swarmData.requestedMacs.length > 0) {
+      payload.requestedMacs = swarmData.requestedMacs;
+    }
+    
+    const response = await apiService.post('/swarms', payload);
     return response.data?.swarm;
   }
 
@@ -196,11 +258,18 @@ class SwarmService {
    */
   async updateSwarm(swarmId, swarmData) {
     try {
-      const response = await apiService.put(`/swarms/${swarmId}`, {
+      const payload = {
         name: swarmData.name,
         description: swarmData.description,
         maxDevices: swarmData.maxDevices,
-      });
+      };
+      
+      // NUEVO: Permitir actualizar MACs solicitadas (solo si el swarm está en estado 'requested')
+      if (swarmData.requestedMacs !== undefined) {
+        payload.requestedMacs = swarmData.requestedMacs;
+      }
+      
+      const response = await apiService.put(`/swarms/${swarmId}`, payload);
       
       return response.data?.swarm || response.data;
     } catch (error) {
@@ -233,6 +302,8 @@ class SwarmService {
       description: swarm.description || "",
       maxDevices: swarm.maxDevices,
       requesterId: swarm.requesterId,
+      // NUEVO: No duplicar MACs solicitadas (dejar que el usuario las configure)
+      // requestedMacs: swarm.requestedMacs
     };
     
     const response = await apiService.post('/swarms', duplicatedData);
@@ -242,17 +313,100 @@ class SwarmService {
   /**
    * Assign a swarm request to the current user
    * Changes swarm status from 'requested' to 'assigned'
+   * ACTUALIZADO: Ahora maneja auto-asignación de dispositivos basada en MACs
    * @param {string} swarmId - ID of the swarm to assign
-   * @returns {Promise<Object>} Updated swarm data
+   * @param {Object} options - Assignment options
+   * @param {boolean} options.autoAssignDevices - Whether to auto-assign devices based on requested MACs
+   * @returns {Promise<Object>} Updated swarm data and assignment results
    */
-  async assignSwarmToMe(swarmId) {
+  async assignSwarmToMe(swarmId, options = { autoAssignDevices: true }) {
     try {
       const response = await apiService.post(`/swarms/${swarmId}/assign`, {
-        clusterManagerId: 1 // TODO: Get this from user context
+        clusterManagerId: 1, // TODO: Get this from user context
+        autoAssignDevices: options.autoAssignDevices
       });
-      return response.data?.swarm || response.data;
+      
+      return {
+        swarm: response.data?.swarm || response.data,
+        // NUEVO: Resultados de auto-asignación de dispositivos
+        autoAssignmentResults: response.data?.autoAssignmentResults || null,
+      };
     } catch (error) {
       throw new Error(`Unable to assign swarm ${swarmId}. ${error.response?.data?.message || error.message}`);
+    }
+  }
+
+  /**
+   * NUEVO: Activate a swarm (transition from 'assigned' to 'active')
+   * @param {string} swarmId - ID of the swarm to activate
+   * @returns {Promise<Object>} Updated swarm data
+   */
+  async activateSwarm(swarmId) {
+    try {
+      const response = await apiService.post(`/swarms/${swarmId}/activate`);
+      return response.data?.swarm || response.data;
+    } catch (error) {
+      throw new Error(`Failed to activate swarm: ${error.response?.data?.message || error.message}`);
+    }
+  }
+
+  /**
+   * NUEVO: Pause a swarm
+   * @param {string} swarmId - ID of the swarm to pause
+   * @returns {Promise<Object>} Updated swarm data
+   */
+  async pauseSwarm(swarmId) {
+    try {
+      const response = await apiService.post(`/swarms/${swarmId}/pause`);
+      return response.data?.swarm || response.data;
+    } catch (error) {
+      throw new Error(`Failed to pause swarm: ${error.response?.data?.message || error.message}`);
+    }
+  }
+
+  /**
+   * NUEVO: Complete a swarm
+   * @param {string} swarmId - ID of the swarm to complete
+   * @returns {Promise<Object>} Updated swarm data
+   */
+  async completeSwarm(swarmId) {
+    try {
+      const response = await apiService.post(`/swarms/${swarmId}/complete`);
+      return response.data?.swarm || response.data;
+    } catch (error) {
+      throw new Error(`Failed to complete swarm: ${error.response?.data?.message || error.message}`);
+    }
+  }
+
+  /**
+   * NUEVO: Reject a swarm request
+   * @param {string} swarmId - ID of the swarm to reject
+   * @returns {Promise<Object>} Updated swarm data
+   */
+  async rejectSwarm(swarmId) {
+    try {
+      const response = await apiService.post(`/swarms/${swarmId}/reject`);
+      return response.data?.swarm || response.data;
+    } catch (error) {
+      throw new Error(`Failed to reject swarm: ${error.response?.data?.message || error.message}`);
+    }
+  }
+
+  /**
+   * NUEVO: Get swarm statistics including MAC assignment stats
+   * @param {string} swarmId - ID of the swarm to get stats for
+   * @returns {Promise<Object>} Swarm statistics
+   */
+  async getSwarmStats(swarmId) {
+    try {
+      const response = await apiService.get(`/swarms/${swarmId}/stats`);
+      return {
+        swarm: response.data?.swarm,
+        stats: response.data?.stats,
+        macsStats: response.data?.macsStats || null,
+      };
+    } catch (error) {
+      throw new Error(`Failed to get swarm stats: ${error.response?.data?.message || error.message}`);
     }
   }
 }


### PR DESCRIPTION
- Add requestedMacs field to Swarm model with validation
- Implement auto-assignment of devices based on requested MACs
- Update SwarmService to handle MAC requests and assignment results
- Add MAC display in SelectSwarmRequests page with assignment feedback
- Update README with MAC address workflow documentation
- Fix Sequelize timestamp issues in controllers

Features:
- Project managers can request specific devices by MAC address
- Auto-assignment when swarm is assigned to cluster manager
- MAC status tracking (available, assigned, not found, assigned elsewhere)
- Enhanced UI showing requested MACs in swarm cards
- Assignment results modal with detailed feedback